### PR TITLE
Fixed a couple of inconsistencies and typos in the API docs

### DIFF
--- a/source/includes/_examples.md
+++ b/source/includes/_examples.md
@@ -29,7 +29,7 @@ Upon matching with a resting sell order with price of `2000 USDT` the new accoun
 
 → The account's available balance is decremented by `1 ETH`.
 
-Upon matching the with a resting sell order with price of `2000 USDT` new account balances are calculated as:
+Upon matching the with a resting sell order with price of `2,000 USDT` new account balances are calculated as:
 
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
 - `Debit Amount = 1 ETH`

--- a/source/includes/_examples.md
+++ b/source/includes/_examples.md
@@ -33,7 +33,7 @@ Upon matching the with a resting sell order with price of `2000 USDT` new accoun
 
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
 - `Debit Amount = 1 ETH`
-- `Credit Amount = 1 * 2,000 - 4 = 1996 USDT`
+- `Credit Amount = 1 * 2,000 - 4 = 1,996 USDT`
 - `Clearing Refund = 0`
 
 ## Adding a Spot Limit Buy Order

--- a/source/includes/_examples.md
+++ b/source/includes/_examples.md
@@ -11,11 +11,11 @@
 
 → The account's available balance is decremented by `3,000 USDT + Taker Fee = 3,006 USDT`.
 
-Upon matching the new account balances are calculated as:
+Upon matching with a resting sell order with price of `2000 USDT` the new account balances are calculated as:
 
 - `Credit Amount = 1 ETH`
-- `Debit Amount = 1 * 2,000 + 4 = 2,004 USDT`
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
+- `Debit Amount = 1 * 2,000 + 4 = 2,004 USDT`
 - `Clearing Refund = 3,006 - 2,004 = 1,002 USDT`
 
 ## Adding a Spot Market Sell Order
@@ -25,15 +25,15 @@ Upon matching the new account balances are calculated as:
 - Market Sell Order:
 
   - `Quantity = 1 ETH`
-  - `Worst Price = 3,000 USDT`
+  - `Worst Price = 1,500 USDT`
 
 → The account's available balance is decremented by `1 ETH`.
 
-Upon matching the new account balances are calculated as:
+Upon matching the with a resting sell order with price of `2000 USDT` new account balances are calculated as:
 
-- `Credit Amount = 1 * 2,000 - 4 = 1996 USDT`
 - `Debit Amount = 1 ETH`
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
+- `Credit Amount = 1 * 2,000 - 4 = 1996 USDT`
 - `Clearing Refund = 0`
 
 ## Adding a Spot Limit Buy Order
@@ -173,7 +173,7 @@ Would result in:
 | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | <table> <tr><th>Price</th><th>Quantity</th></tr><tr><td>$64,390</td><td>0.3 BTC</td></tr><tr><td>$64,370</td><td>0.2 BTC</td></tr></table> | <table> <tr><th>Price</th><th>Quantity</th></tr><tr><td>$64,205</td><td>0.2 BTC</td></tr><tr><td>$64,200</td><td>0.2 BTC</td></tr> </table> |
 
-**Market Buys**: Matching the highest priced market buy order first for 0.4 BTC. Now for the second market buy order only 0.1 BTC is left at matchable price, meaning the other 0.1 BTC in the order will be cancelled. Both orders will be matched with the single resting limit order at a price of 64,350 for a total quantity of 0.5 BTC.
+**Market Buys**: Matching the highest priced market buy order first for 0.4 BTC. Now for the second market buy order only 0.1 BTC is left at matchable price, meaning the other 0.1 BTC in the order will be cancelled. Both orders will be matched with the single resting limit order at a price of 64,360 for a total quantity of 0.5 BTC.
 
 **Market Sells**: Matching the first two market sell orders for at a matching price of `(64,210*0.1 + 64,205*0.2) / 0.3 = 64,206.67` for a total quantity of 0.3 BTC. The resting limit orders are both matched at their specified price points of 64,210 and 64,205. Since the last market sell order of 69,000 cannot be fulfilled, it is cancelled.
 

--- a/source/includes/_examples.md
+++ b/source/includes/_examples.md
@@ -13,8 +13,8 @@
 
 Upon matching with a resting sell order with price of `2000 USDT` the new account balances are calculated as:
 
-- `Credit Amount = 1 ETH`
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
+- `Credit Amount = 1 ETH`
 - `Debit Amount = 1 * 2,000 + 4 = 2,004 USDT`
 - `Clearing Refund = 3,006 - 2,004 = 1,002 USDT`
 
@@ -31,8 +31,8 @@ Upon matching with a resting sell order with price of `2000 USDT` the new accoun
 
 Upon matching the with a resting sell order with price of `2000 USDT` new account balances are calculated as:
 
-- `Debit Amount = 1 ETH`
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
+- `Debit Amount = 1 ETH`
 - `Credit Amount = 1 * 2,000 - 4 = 1996 USDT`
 - `Clearing Refund = 0`
 
@@ -55,17 +55,17 @@ If **Unmatched**, the order becomes a resting limit order (maker) and we refund 
 
 If **Matched Immediately**: (assuming an FBA clearing price of 1,900 USDT)
 
+- `Trading Fee = 1 * 1,900 * 0.002 = 3.8 USDT`
 - `Credit Amount = 1 ETH`
 - `Debit Amount = 1 * 1,900 + 3.8 = 1,903.8 USDT`
-- `Trading Fee = 1 * 1,900 * 0.002 = 3.8 USDT`
 - `Clearing Refund = (1 + 0.002) * (2,000 - 1,900) = 100.2 USDT`
 - `Unmatched Fee Refund = 0 USDT`
 
 If **Filled Later By Market Order**:
 
+- `Trading Fee = 1 * 2,000 * 0.001 = 2 USDT`
 - `Credit Amount (in base asset) = 1 ETH`
 - `Debit Amount (in quote asset) = 1 * 2,000 + 2 = 2,002 USDT`
-- `Trading Fee = 1 * 2,000 * 0.001 = 2 USDT`
 
 ## Adding a Spot Limit Sell Order
 
@@ -84,11 +84,11 @@ If **Unmatched**, the order becomes a resting limit order (maker) and we refund 
 
 - `Fee Refund = 0 ETH`
 
-If **Matched Immediately**: (assuming an FBA clearing price of 1,900 USDT)
+If **Matched Immediately**: (assuming an FBA clearing price of 2,100 USDT)
 
+- `Trading Fee = 1 * 2,100 * 0.002 = 4.2 USDT`
 - `Credit Amount = 1 * 2,100 * (1 - 0.002) = 2,095.8 USDT`
 - `Debit Amount = 1 ETH`
-- `Trading Fee = 1 * 2,100 * 0.002 = 4.2 USDT`
 - `Clearing Refund = 0 ETH`
 - `Fee Refund = 0 USDT`
 

--- a/source/includes/_examples.md
+++ b/source/includes/_examples.md
@@ -11,7 +11,7 @@
 
 → The account's available balance is decremented by `3,000 USDT + Taker Fee = 3,006 USDT`.
 
-Upon matching with a resting sell order with price of `2000 USDT` the new account balances are calculated as:
+Upon matching with a resting sell order with price of `2,000 USDT` the new account balances are calculated as:
 
 - `Trading Fee = 1 * 2,000 * 0.002 = 4 USDT`
 - `Credit Amount = 1 ETH`

--- a/source/includes/_faq.md
+++ b/source/includes/_faq.md
@@ -37,7 +37,7 @@
 	No, there are currently no limits in the API requests.
 
 ## 8. What is the normal order latency I can expect?
-	There's no guarantee on when the exchange will process your transaction. It depends on the peer to peer gossip of the network and whether your transaction reaches a given block producer to get included in a block. You can read more details about this here [https://docs.tendermint.com/master/assets/img/tm-transaction-flow.258ca020.png](https://docs.tendermint.com/master/assets/img/tm-transaction-flow.258ca020.png) as well as the docs here [https://docs.tendermint.com/master/introduction/what-is-tendermint.html](https://docs.tendermint.com/master/introduction/what-is-tendermint.html)
+	There's no guarantee on when the exchange will process your transaction. It depends on the peer to peer gossip of the network and whether your transaction reaches a given block producer to get included in a block. You can read more details about this here [https://docs.tendermint.com/v0.35/assets/img/tm-transaction-flow.258ca020.png](https://docs.tendermint.com/v0.35/assets/img/tm-transaction-flow.258ca020.png) as well as the docs here [https://docs.tendermint.com/v0.35/introduction/what-is-tendermint.html](https://docs.tendermint.com/v0.35/introduction/what-is-tendermint.html)
 
 	We strongly recommend following the guide to setup your own infrastructure which will ultimately reduce latency to a great extent.
 

--- a/source/includes/_overview.md
+++ b/source/includes/_overview.md
@@ -55,7 +55,7 @@ When you submit an order to Injective Chain,
 
 ## Frequent Batch Auction (FBA)
 
-The goal is to further prevent any [Front-Running](https://www.investopedia.com/terms/f/frontrunning.asp) in a decentralized setting. Most DEX's suffer from this as all information is public and traders can collide with miners or pay high gas fees enabling them to front-run any trades. We mitigate this by fast block times combined with a Frequent Batch Auction:
+The goal is to further prevent any [Front-Running](https://www.investopedia.com/terms/f/frontrunning.asp) in a decentralized setting. Most DEX's suffer from this as all information is public and traders can collude with miners or pay high gas fees enabling them to front-run any trades. We mitigate this by fast block times combined with a Frequent Batch Auction:
 
 In any given block:
 
@@ -232,23 +232,23 @@ This has some implications when placing new orders.
 
 In our example, consider a new reduce-only order of `0.4 BTC` at `$64,600`.
 
-|  Buy Price  |  Quantity   |   Order Type    |
-| :---------: | :---------: | :-------------: |
-|   $66,500   |   0.2 BTC   |     Vanilla     |
-|   $65,500   |   0.2 BTC   |   Reduce-only   |
-| **$64,600** | **0.4 BTC** | **Reduce-only** |
-|   $64,500   |   0.3 BTC   |     Vanilla     |
-|   $63,500   |   0.1 BTC   |   Reduce-only   |
+|  Sell Price  |  Quantity   |   Order Type    |
+| :---------:  | :---------: | :-------------: |
+|   $66,500    |   0.2 BTC   |     Vanilla     |
+|   $65,500    |   0.2 BTC   |   Reduce-only   |
+| **$64,600**  | **0.4 BTC** | **Reduce-only** |
+|   $64,500    |   0.3 BTC   |     Vanilla     |
+|   $63,500    |   0.1 BTC   |   Reduce-only   |
 
 This is perfectly valid and no further action is required. But what if the order was for `0.5 BTC` instead?
 
-|  Buy Price  |  Quantity   |   Order Type    |
-| :---------: | :---------: | :-------------: |
-|   $66,500   |   0.2 BTC   |     Vanilla     |
-|   $65,500   |   0.2 BTC   |   Reduce-only   |
-| **$64,600** | **0.5 BTC** | **Reduce-only** |
-|   $64,500   |   0.3 BTC   |     Vanilla     |
-|   $63,500   |   0.1 BTC   |   Reduce-only   |
+|  Sell Price  |  Quantity   |   Order Type    |
+| :---------:  | :---------: | :-------------: |
+|   $66,500    |   0.2 BTC   |     Vanilla     |
+|   $65,500    |   0.2 BTC   |   Reduce-only   |
+| **$64,600**  | **0.5 BTC** | **Reduce-only** |
+|   $64,500    |   0.3 BTC   |     Vanilla     |
+|   $63,500    |   0.1 BTC   |   Reduce-only   |
 
 If the orders are getting matched, once the last reduce-only of $65,500 with 0.2 BTC order is reached, the position will have been reduced to `1 BTC - 0.1 BTC - 0.3 BTC - 0.5 BTC = 0.1 BTC`. A reduce-only order of 0.2 BTC after that will thus be invalid.
 
@@ -260,23 +260,23 @@ To prevent that, we simply **reject the creation of the new 0.5 BTC reduce-only 
 
 In our example, consider a new vanilla order of `0.4 BTC` at `$64,600`.
 
-|  Buy Price  |  Quantity   | Order Type  |
-| :---------: | :---------: | :---------: |
-|   $66,500   |   0.2 BTC   |   Vanilla   |
-|   $65,500   |   0.2 BTC   | Reduce-only |
-| **$64,600** | **0.4 BTC** | **Vanilla** |
-|   $64,500   |   0.3 BTC   |   Vanilla   |
-|   $63,500   |   0.1 BTC   | Reduce-only |
+|  Sell Price  |  Quantity   | Order Type  |
+| :---------:  | :---------: | :---------: |
+|   $66,500    |   0.2 BTC   |   Vanilla   |
+|   $65,500    |   0.2 BTC   | Reduce-only |
+| **$64,600**  | **0.4 BTC** | **Vanilla** |
+|   $64,500    |   0.3 BTC   |   Vanilla   |
+|   $63,500    |   0.1 BTC   | Reduce-only |
 
 Again this perfectly valid and no further action is required. But what if the order was for `0.5 BTC` instead?
 
-|  Buy Price  |  Quantity   | Order Type  |
-| :---------: | :---------: | :---------: |
-|   $66,500   |   0.2 BTC   |   Vanilla   |
-|   $65,500   |   0.2 BTC   | Reduce-only |
-| **$64,600** | **0.5 BTC** | **Vanilla** |
-|   $64,500   |   0.3 BTC   |   Vanilla   |
-|   $63,500   |   0.1 BTC   | Reduce-only |
+|  Sell Price  |  Quantity   | Order Type  |
+| :---------:  | :---------: | :---------: |
+|   $66,500    |   0.2 BTC   |   Vanilla   |
+|   $65,500    |   0.2 BTC   | Reduce-only |
+| **$64,600**  | **0.5 BTC** | **Vanilla** |
+|   $64,500    |   0.3 BTC   |   Vanilla   |
+|   $63,500    |   0.1 BTC   | Reduce-only |
 
 If the orders are getting matched, once the last reduce-only of $65,500 with 0.2 BTC order is reached, the position will have been reduced to `1 BTC - 0.1 BTC - 0.3 BTC - 0.5 BTC = 0.1 BTC`. A reduce-only order of 0.2 BTC after that will thus be invalid.
 


### PR DESCRIPTION
When going through the API docs I mentioned a couple of types or explanations that weren't entirely clear (or had some small mistakes in them) so I took the liberty of fixing them.