### PR TITLE
chore: deprecate orderbook v1

### DIFF
--- a/source/includes/_derivativesrpc.md
+++ b/source/includes/_derivativesrpc.md
@@ -2413,7 +2413,9 @@ timestamp: 1652793296000
 
 Get the orderbook of a derivative market.
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
 
 
 ### Request Parameters
@@ -2653,7 +2655,9 @@ orderbook {
 
 Get the orderbook for an array of derivative markets.  
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:
@@ -2912,7 +2916,9 @@ orderbooks {
 
 Stream orderbook updates for an array of derivative markets.  
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [StreamOrderbooksV2](#injectivederivativeexchangerpc-streamorderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:

--- a/source/includes/_derivativesrpc.md
+++ b/source/includes/_derivativesrpc.md
@@ -2409,9 +2409,12 @@ timestamp: 1652793296000
 |created_at|Integer|Position created timestamp in UNIX millis. Currently not supported (value will be inaccurate).|
 
 
-## Orderbook
+## \[DEPRECATED\] Orderbook
 
 Get the orderbook of a derivative market.
+
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
+
 
 ### Request Parameters
 > Request Example:
@@ -2646,9 +2649,11 @@ orderbook {
 |price|String|Price number of the price level|
 
 
-## Orderbooks
+## \[DEPRECATED\] Orderbooks
 
-Get the orderbook for an array of derivative markets.
+Get the orderbook for an array of derivative markets.  
+
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivederivativeexchangerpc-orderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:
@@ -2903,10 +2908,11 @@ orderbooks {
 |price|String|Price number of the price level|
 
 
-## StreamOrderbooks
+## \[DEPRECATED\] StreamOrderbooks
 
-Stream orderbook updates for an array of derivative markets.
+Stream orderbook updates for an array of derivative markets.  
 
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [StreamOrderbooksV2](#injectivederivativeexchangerpc-streamorderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:
@@ -3201,9 +3207,9 @@ market_id: "0x90e662193fa29a3a7e6c07be4407c94833e762d9ee82136a2cc712d6b87d7de3"
 |price|String|Price number of the price level|
 
 
-## OrderbooksV2 (Experimental)
+## OrderbooksV2
 
-Get an orderbook snapshot for one or more derivative markets. This API is currently experimental but offers better performance than V1.
+Get an orderbook snapshot for one or more derivative markets.
 
 ### Request Parameters
 > Request Example:
@@ -3355,9 +3361,9 @@ orderbooks {
 |price|String|Price number of the price level|
 
 
-## StreamOrderbooksV2 (Experimental)
+## StreamOrderbooksV2
 
-Stream orderbook snapshot updates for one or more derivative markets. This API is currently experimental but offers better performance than V1.
+Stream orderbook snapshot updates for one or more derivative markets
 
 
 ### Request Parameters
@@ -3484,9 +3490,9 @@ market_id: "0x90e662193fa29a3a7e6c07be4407c94833e762d9ee82136a2cc712d6b87d7de3"
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## StreamOrderbookUpdate (Experimental)
+## StreamOrderbookUpdate
 
-Stream incremental orderbook updates for one or more derivative markets. This stream should be started prior to obtaining orderbook snapshots so that no incremental updates are omitted between obtaining a snapshot and starting the update stream. This API is currently experimental.
+Stream incremental orderbook updates for one or more derivative markets. This stream should be started prior to obtaining orderbook snapshots so that no incremental updates are omitted between obtaining a snapshot and starting the update stream.
 
 
 ### Request Parameters

--- a/source/includes/_spotrpc.md
+++ b/source/includes/_spotrpc.md
@@ -1606,7 +1606,9 @@ timestamp: 1676015260000
 
 Get the orderbook of a spot market.
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbookV2](#injectivespotexchangerpc-orderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivespotexchangerpc-orderbooksv2) instead.
 
 
 ### Request Parameters
@@ -1833,7 +1835,9 @@ orderbook {
 
 Get the orderbooks for one or more spot markets.  
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivespotexchangerpc-orderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivespotexchangerpc-orderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:
@@ -2139,7 +2143,9 @@ orderbooks {
 
 Stream orderbook updates for an array of spot markets.  
 
-Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [StreamOrderbookV2](#injectivespotexchangerpc-streamorderbooksv2) instead.
+**Deprecation warning**
+
+This API will be removed on April 5, 2023 on testnet and on April 22, 2023 on mainnet. Please use the new api [OrderbookV2](#injectivespotexchangerpc-orderbooksv2) instead.
 
 
 ### Request Parameters

--- a/source/includes/_spotrpc.md
+++ b/source/includes/_spotrpc.md
@@ -1602,9 +1602,11 @@ timestamp: 1676015260000
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## Orderbook
+## \[DEPRECATED\] Orderbook
 
 Get the orderbook of a spot market.
+
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbookV2](#injectivespotexchangerpc-orderbooksv2) instead.
 
 
 ### Request Parameters
@@ -1827,10 +1829,11 @@ orderbook {
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## Orderbooks
+## \[DEPRECATED\] Orderbooks
 
-Get the orderbooks for one or more spot markets.
+Get the orderbooks for one or more spot markets.  
 
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [OrderbooksV2](#injectivespotexchangerpc-orderbooksv2) instead.
 
 ### Request Parameters
 > Request Example:
@@ -2132,9 +2135,11 @@ orderbooks {
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## StreamOrderbooks
+## \[DEPRECATED\] StreamOrderbooks
 
-Stream orderbook updates for an array of spot markets.
+Stream orderbook updates for an array of spot markets.  
+
+Deprecation warning: this api will be removed on April 5th 2023 on test net and on 22th on main net. Please use the new api [StreamOrderbookV2](#injectivespotexchangerpc-streamorderbooksv2) instead.
 
 
 ### Request Parameters
@@ -2418,9 +2423,9 @@ market_id: "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## OrderbooksV2 (Experimental)
+## OrderbooksV2
 
-Get an orderbook snapshot for one or more spot markets. This API is currently experimental but offers better performance than V1.
+Get an orderbook snapshot for one or more spot markets.
 
 
 ### Request Parameters
@@ -2557,9 +2562,9 @@ orderbooks {
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## StreamOrderbooksV2 (Experimental)
+## StreamOrderbooksV2
 
-Stream orderbook snapshot updates for one or more spot markets. This API is currently experimental but offers better performance than V1.
+Stream orderbook snapshot updates for one or more spot markets.
 
 
 ### Request Parameters
@@ -2681,9 +2686,9 @@ market_id: "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
 |timestamp|Integer|Price level last updated timestamp in UNIX millis|
 
 
-## StreamOrderbookUpdate (Experimental)
+## StreamOrderbookUpdate
 
-Stream incremental orderbook updates for one or more spot markets. This stream should be started prior to obtaining orderbook snapshots so that no incremental updates are omitted between obtaining a snapshot and starting the update stream. This API is currently experimental.
+Stream incremental orderbook updates for one or more spot markets. This stream should be started prior to obtaining orderbook snapshots so that no incremental updates are omitted between obtaining a snapshot and starting the update stream.
 
 
 ### Request Parameters


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

This PR aim to deprecate Portfolio V1 apis