### PR TITLE
fix/update_create_order_message_examples

### DIFF
--- a/source/includes/_authz.md
+++ b/source/includes/_authz.md
@@ -466,7 +466,6 @@ func main() {
 	price := decimal.NewFromFloat(22.55)
 	order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY,
 			Quantity:     amount,

--- a/source/includes/_binaryoptions.md
+++ b/source/includes/_binaryoptions.md
@@ -1084,7 +1084,6 @@ func main() {
 
 	spot_order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     samount,
@@ -1104,7 +1103,6 @@ func main() {
 
 	derivative_order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     damount,

--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2023-01-25
+- Python SDK v1.2.0
+  - Improved message based gas estimator to consider that Post Only orders creation require more gas than normal orders
+
 ## 2023-01-02
 - Python SDK v1.0 and Go SDK v1.49
   - Added logic to support use of Client Order ID (CID) new identifier in OrderInfo

--- a/source/includes/_derivatives.md
+++ b/source/includes/_derivatives.md
@@ -190,7 +190,6 @@ func main() {
 
 	order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
 			Quantity:     amount,
@@ -471,7 +470,6 @@ func main() {
 
 	order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     amount,
@@ -1056,7 +1054,6 @@ func main() {
 
 	spot_order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     samount,
@@ -1076,7 +1073,6 @@ func main() {
 
 	derivative_order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     damount,
@@ -1803,7 +1799,6 @@ func main() {
 
 	spotOrder := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY,
 			Quantity:     decimal.NewFromFloat(2),
@@ -1817,7 +1812,6 @@ func main() {
 
 	derivativeOrder := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_BUY,
 			Quantity:     decimal.NewFromFloat(2),
@@ -2182,7 +2176,6 @@ func main() {
 
 	order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_SELL,
 			Quantity:     amount,

--- a/source/includes/_spot.md
+++ b/source/includes/_spot.md
@@ -187,7 +187,6 @@ func main() {
 
 	order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_SELL, //BUY SELL
 			Quantity:     amount,
@@ -465,7 +464,6 @@ func main() {
 
 	order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     amount,
@@ -1036,7 +1034,6 @@ func main() {
 
 	spot_order := chainClient.CreateSpotOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.SpotOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     samount,
@@ -1056,7 +1053,6 @@ func main() {
 
 	derivative_order := chainClient.CreateDerivativeOrder(
 		defaultSubaccountID,
-		network,
 		&chainclient.DerivativeOrderData{
 			OrderType:    exchangetypes.OrderType_BUY, //BUY SELL BUY_PO SELL_PO
 			Quantity:     damount,


### PR DESCRIPTION
- Fix order creation examples in Go SDK to remove the `network` parameter